### PR TITLE
Add global -t a.k.a. --triggers-as-axes option.

### DIFF
--- a/src/joyosc/Config.cpp
+++ b/src/joyosc/Config.cpp
@@ -125,7 +125,8 @@ bool Config::parseCommandLine(int argc, char **argv) {
 		EVENTS,
 		JSONLY,
 		WINDOW,
-		SLEEP
+		SLEEP,
+		TRIGGER
 	};
 
 	// option and usage print descriptors
@@ -141,6 +142,7 @@ bool Config::parseCommandLine(int argc, char **argv) {
 		{JSONLY, 0, "j", "joysticks-only", Options::Arg::None, "  -j, --joysticks-only \tDisable game controller support, joystick interface only"},
 		{WINDOW, 0, "w", "window", Options::Arg::None, "  -w, --window \tOpen window, helps on some platforms if device events are not being found, ex. MFI controllers on macOS"},
 		{SLEEP, 0, "s", "sleep", Options::Arg::Integer, "  -s, --sleep \tSleep time in usecs (default: 10000)"},
+		{TRIGGER, 0, "t", "triggers-as-axes", Options::Arg::None, "  -t, --triggers-as-axes \tReport trigger buttons as axis values"},
 		{UNKNOWN, 0, "", "", Options::Arg::Unknown, "\nArguments:"},
 		{UNKNOWN, 0, "", "", Options::Arg::None, "  FILE \tOptional XML config file"},
 		{0, 0, 0, 0, 0, 0}
@@ -178,6 +180,7 @@ bool Config::parseCommandLine(int argc, char **argv) {
 	if(options.isSet(JSONLY))     {joysticksOnly = true;}
 	if(options.isSet(WINDOW))     {openWindow = true;}
 	if(options.isSet(SLEEP))      {sleepUS = options.getUInt(SLEEP);}
+	if(options.isSet(TRIGGER))     {triggersAsAxes = true;}
 
 	return true;
 }

--- a/src/joyosc/Config.h
+++ b/src/joyosc/Config.h
@@ -68,6 +68,7 @@ class Config {
 		std::string deviceAddress = "/devices"; ///< base osc sending addess for devices
 		
 		bool printEvents = false; ///< print lots of events?
+		bool triggersAsAxes = false; ///< report trigger buttons as axis values
 		bool joysticksOnly = false; ///< disable game controller support?
 		bool openWindow = false; ///< open window? helps to receive events on some platforms
 

--- a/src/joyosc/GameController.cpp
+++ b/src/joyosc/GameController.cpp
@@ -142,7 +142,7 @@ bool GameController::handleEvent(void *data) {
 			
 			// trigger buttons for some devices are reported as axis values,
 			// forward them as buttons unless desired as axes
-			if(!m_triggersAsAxes && (axis == "lefttrigger" || axis == "righttrigger")) {
+			if(!m_config.triggersAsAxes && !m_triggersAsAxes && (axis == "lefttrigger" || axis == "righttrigger")) {
 				return buttonPressed(axis, (event->caxis.value > 0 ? 1 : 0));
 			}
 			


### PR DESCRIPTION
I use this all the time, and having to specify it for each and every controller in the config file is tedious, so I also added a `-t` option which enables triggers-as-axes globally.