### PR TITLE
Add touchpad support for Playstation controllers and the like.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Options:
                        not being found, ex. MFi controllers on macOS
   -s, --sleep          Sleep time in usecs (default: 10000)
   -t, --triggers       Report trigger buttons as axis values
+  -r, --sensors        Report sensor values (gyro, accelerometer)
 
 Arguments:
   FILE                 Optional XML config file(s)
@@ -261,6 +262,8 @@ SDL Game Controller button names: a, b, x, y, start, back, guide, leftshoulder, 
 
 SDL Game Controller axis names: leftx, lefty, rightx, righty
 
+Also, joyosc can report x, y, z motion (acceleration and gyro aka rotation) data on devices which support this when invoked with the `--sensors` option. These use the following sensor names: accel, gyro (also leftaccel, leftgyro and rightaccel, rightgyro on some devices). _Note: These will generate lots of data when enabled._
+
 _Note: Game Controller names seem to follow the general Playstation DualShock layout. Devices with more than 4 axes and ~20 buttons are probably best used as Joysticks._
 
 If you do not want to use the Game Controller interface and stick with Joysticks only, use the `--joysticks-only` commandline option.
@@ -274,11 +277,12 @@ joyosc streams device event information in the following OSC address format:
     /joyosc/devices/DEVICE_NAME/INPUT_TYPE ID VALUE
 
 * _DEVICE_NAME_ is the mapped name to the device as specified in the config file, otherwise it is "gc#" or "js#" with # being the current device id
-* _INPUT_TYPE_ can be `button`, `axis`, `ball`, or `hat` for joysticks and `button` or `axis` for game controllers
-* _ID_ is the joystick id number or game controller name string for the control (aka joystick button 1, axis 2, etc / game controller button x, axis lefty, etc); these are likely different between joystick devices but largely the same between game controllers
+* _INPUT_TYPE_ can be `button`, `axis`, `ball`, or `hat` for joysticks and `button`, `axis`, or `sensor` for game controllers
+* _ID_ is the joystick id number or game controller name string for the control (aka joystick button 1, axis 2, etc / game controller button x, axis lefty, sensor gyro, etc); these are likely different between joystick devices but largely the same between game controllers
 * _VALUE_ is the current value of the control:
   * button state values are 1 or 0 for pressed & released
   * axis values are -32767 to 32767 (signed 16 bit)
+  * sensor values are triples of x, y, z floating point values in m/s^2 (accelerometer) or radians/s (gyro), see the [SDL docs](https://wiki.libsdl.org/SDL2/SDL_SensorType#remarks) for details
   * hat values are binary bits representing the hat button aka: 0, 2, 4, 8
   * (track)ball values are relative x & y movement in pixels (I think, SDL docs don't go into details)
 
@@ -295,9 +299,9 @@ Example game controller messages:
 /joyosc/devices/gc0/button lefttrigger 0
 /joyosc/devices/gc0/axis righty 32767
 ~~~
- 
+
 #### Notifications
- 
+
 joyosc also sends status notification messages:
 ~~~
 /joyosc/notifications/startup

--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ SDL Game Controller button names: a, b, x, y, start, back, guide, leftshoulder, 
 
 SDL Game Controller axis names: leftx, lefty, rightx, righty
 
+On devices with a touchpad, such as the Playstation controllers, joyosc reports touchpad down, up, and motion events using the touchpaddown, touchpadup, and touchpad names, followed by five (two integer and three floating point) arguments: touchpad index (this will usually be 0, but may report higher indices if the device has more than one touchpad), finger index (starting at 0; higher values may be reported if the touchpad supports multi-touch), x and y (touchpad coordinates in the 0-1 range; upper left corner is 0, 0), and pressure (in the 0-1 range; 0 means no touch).
+
 Also, joyosc can report x, y, z motion (acceleration and gyro aka rotation) data on devices which support this when invoked with the `--sensors` option. These use the following sensor names: accel, gyro (also leftaccel, leftgyro and rightaccel, rightgyro on some devices). _Note: These will generate lots of data when enabled._
 
 _Note: Game Controller names seem to follow the general Playstation DualShock layout. Devices with more than 4 axes and ~20 buttons are probably best used as Joysticks._

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,10 @@ PKG_CHECK_MODULES([TINYXML2], [tinyxml2 >= 6], [],
 	AC_MSG_ERROR([tinyxml2 library >= 6.0.0 not found]))
 
 # check for sensor constants
+if test `uname -s` = Darwin; then
+# make sure that the SDL2 headers from Homebrew are found on Darwin arm64
+CPPFLAGS="-I/opt/homebrew/include ${CPPFLAGS}"
+fi
 AC_CHECK_DECLS(SDL_SENSOR_ACCEL_L, , , [#include <SDL2/SDL_sensor.h>])
 
 #########################################

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,9 @@ PKG_CHECK_MODULES([LO], [liblo >= 0.23], [],
 PKG_CHECK_MODULES([TINYXML2], [tinyxml2 >= 6], [],
 	AC_MSG_ERROR([tinyxml2 library >= 6.0.0 not found]))
 
+# check for sensor constants
+AC_CHECK_DECLS(SDL_SENSOR_ACCEL_L, , , [#include <SDL2/SDL_sensor.h>])
+
 #########################################
 ##### Build options #####
 

--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,7 @@ PKG_CHECK_MODULES([TINYXML2], [tinyxml2 >= 6], [],
 # check for sensor constants
 if test `uname -s` = Darwin; then
 # make sure that the SDL2 headers from Homebrew are found on Darwin arm64
-CPPFLAGS="-I/opt/homebrew/include ${CPPFLAGS}"
+CPPFLAGS="${CPPFLAGS} ${SDL_CFLAGS}"
 fi
 AC_CHECK_DECLS(SDL_SENSOR_ACCEL_L, , , [#include <SDL2/SDL_sensor.h>])
 

--- a/src/joyosc/Config.cpp
+++ b/src/joyosc/Config.cpp
@@ -74,7 +74,8 @@ bool Config::parseCommandLine(int argc, char **argv) {
 		JSONLY,
 		WINDOW,
 		SLEEP,
-		TRIGGER
+		TRIGGER,
+		SENSORS
 	};
 
 	// option and usage print descriptors
@@ -91,6 +92,7 @@ bool Config::parseCommandLine(int argc, char **argv) {
 		{WINDOW, 0, "w", "window", Options::Arg::None, "  -w, --window \tOpen window, helps on some platforms if device events are not being found, ex. MFi controllers on macOS"},
 		{SLEEP, 0, "s", "sleep", Options::Arg::Integer, "  -s, --sleep \tSleep time in usecs (default: 10000)"},
 		{TRIGGER, 0, "t", "triggers", Options::Arg::None, "  -t, --triggers \tReport trigger buttons as axis values"},
+		{SENSORS, 0, "r", "sensors", Options::Arg::None, "  -r, --sensors \tReport sensor values (gyro, accelerometer)"},
 		{UNKNOWN, 0, "", "", Options::Arg::Unknown, "\nArguments:"},
 		{UNKNOWN, 0, "", "", Options::Arg::None, "  FILE \tOptional XML config file(s)"},
 		{0, 0, 0, 0, 0, 0}
@@ -129,6 +131,7 @@ bool Config::parseCommandLine(int argc, char **argv) {
 	if(options.isSet(WINDOW))     {openWindow = true;}
 	if(options.isSet(SLEEP))      {sleepUS = options.getUInt(SLEEP);}
 	if(options.isSet(TRIGGER))    {triggersAsAxes = true;}
+	if(options.isSet(SENSORS))    {enableSensors = true;}
 
 	return true;
 }
@@ -215,6 +218,7 @@ void Config::print() {
 	    << "joysticks only?: " << (joysticksOnly ? "true" : "false") << std::endl
 	    << "sleep us:        " << sleepUS << std::endl
 	    << "triggers as axes?: " << (triggersAsAxes ? "true" : "false") << std::endl
+	    << "enable sensors?: " << (enableSensors ? "true" : "false") << std::endl
 	    << "device addresses: " << m_devices.size() << std::endl;
 	int index = 0;
 	for(auto &device : m_devices) {

--- a/src/joyosc/Config.h
+++ b/src/joyosc/Config.h
@@ -72,6 +72,7 @@ class Config {
 		bool openWindow = false; ///< open window? helps to receive events on some platforms
 		unsigned int sleepUS = 10000; ///< how long to sleep in the run loop
 		bool triggersAsAxes = false; ///< report trigger buttons as axis values
+		bool enableSensors = false; ///< report sensor values (gyro, accelerometer)
 
 	/// \section Getters
 

--- a/src/joyosc/DeviceManager.cpp
+++ b/src/joyosc/DeviceManager.cpp
@@ -120,6 +120,7 @@ bool DeviceManager::handleEvent(SDL_Event *event) {
 			LOG_DEBUG << "CONTROLLER REMAPPED instance ID " << event->cdevice.which << std::endl;
 			return true;
 			
+		case SDL_CONTROLLERSENSORUPDATE:
 		case SDL_CONTROLLERAXISMOTION:
 		case SDL_CONTROLLERBUTTONDOWN: case SDL_CONTROLLERBUTTONUP:
 			if(getDeviceType(event->cdevice.which) == Device::GAMECONTROLLER) {

--- a/src/joyosc/DeviceManager.cpp
+++ b/src/joyosc/DeviceManager.cpp
@@ -121,6 +121,9 @@ bool DeviceManager::handleEvent(SDL_Event *event) {
 			return true;
 			
 		case SDL_CONTROLLERSENSORUPDATE:
+		case SDL_CONTROLLERTOUCHPADDOWN:
+		case SDL_CONTROLLERTOUCHPADUP:
+		case SDL_CONTROLLERTOUCHPADMOTION:
 		case SDL_CONTROLLERAXISMOTION:
 		case SDL_CONTROLLERBUTTONDOWN: case SDL_CONTROLLERBUTTONUP:
 			if(getDeviceType(event->cdevice.which) == Device::GAMECONTROLLER) {

--- a/src/joyosc/GameController.cpp
+++ b/src/joyosc/GameController.cpp
@@ -33,7 +33,7 @@ static const char *GetSensorName(SDL_SensorType sensor)
         return "accelerometer";
     case SDL_SENSOR_GYRO:
         return "gyro";
-#if 0 // these are only in newer SDL versions, disabled for now
+#if HAVE_DECL_SDL_SENSOR_ACCEL_L
     case SDL_SENSOR_ACCEL_L:
         return "accelerometer (L)";
     case SDL_SENSOR_GYRO_L:
@@ -122,7 +122,7 @@ bool GameController::open(void *data) {
 	  SDL_SensorType sensors[] = {
 	    SDL_SENSOR_ACCEL,
 	    SDL_SENSOR_GYRO,
-#if 0 // these are only in newer SDL versions, disabled for now
+#if HAVE_DECL_SDL_SENSOR_ACCEL_L
 	    SDL_SENSOR_ACCEL_L,
 	    SDL_SENSOR_GYRO_L,
 	    SDL_SENSOR_ACCEL_R,

--- a/src/joyosc/GameController.cpp
+++ b/src/joyosc/GameController.cpp
@@ -30,18 +30,18 @@ static const char *GetSensorName(SDL_SensorType sensor)
 {
     switch (sensor) {
     case SDL_SENSOR_ACCEL:
-        return "accelerometer";
+        return "accel";
     case SDL_SENSOR_GYRO:
         return "gyro";
 #if HAVE_DECL_SDL_SENSOR_ACCEL_L
     case SDL_SENSOR_ACCEL_L:
-        return "accelerometer (L)";
+        return "leftaccel";
     case SDL_SENSOR_GYRO_L:
-        return "gyro (L)";
+        return "leftgyro";
     case SDL_SENSOR_ACCEL_R:
-        return "accelerometer (R)";
+        return "rightaccel";
     case SDL_SENSOR_GYRO_R:
-        return "gyro (R)";
+        return "rightgyro";
 #endif
     default:
         return "UNKNOWN";

--- a/src/joyosc/GameController.cpp
+++ b/src/joyosc/GameController.cpp
@@ -33,6 +33,7 @@ static const char *GetSensorName(SDL_SensorType sensor)
         return "accelerometer";
     case SDL_SENSOR_GYRO:
         return "gyro";
+#if 0 // these are only in newer SDL versions, disabled for now
     case SDL_SENSOR_ACCEL_L:
         return "accelerometer (L)";
     case SDL_SENSOR_GYRO_L:
@@ -41,6 +42,7 @@ static const char *GetSensorName(SDL_SensorType sensor)
         return "accelerometer (R)";
     case SDL_SENSOR_GYRO_R:
         return "gyro (R)";
+#endif
     default:
         return "UNKNOWN";
     }
@@ -120,10 +122,12 @@ bool GameController::open(void *data) {
 	  SDL_SensorType sensors[] = {
 	    SDL_SENSOR_ACCEL,
 	    SDL_SENSOR_GYRO,
+#if 0 // these are only in newer SDL versions, disabled for now
 	    SDL_SENSOR_ACCEL_L,
 	    SDL_SENSOR_GYRO_L,
 	    SDL_SENSOR_ACCEL_R,
 	    SDL_SENSOR_GYRO_R
+#endif
 	  };
 	  for (unsigned int i = 0; i < SDL_arraysize(sensors); ++i) {
 	    SDL_SensorType sensor = sensors[i];

--- a/src/joyosc/GameController.cpp
+++ b/src/joyosc/GameController.cpp
@@ -185,6 +185,26 @@ bool GameController::handleEvent(void *data) {
 			return buttonPressed(button, event->cbutton.state);
 		}
 
+		case SDL_CONTROLLERTOUCHPADDOWN:
+		case SDL_CONTROLLERTOUCHPADUP:
+		case SDL_CONTROLLERTOUCHPADMOTION: {
+			std::string action = event->type==SDL_CONTROLLERTOUCHPADDOWN ? "touchpaddown" : event->type==SDL_CONTROLLERTOUCHPADUP ? "touchpadup" : "touchpad";
+			lo::Address *sender = m_config.getOscSender();
+			sender->send(m_config.deviceAddress + m_oscAddress + "/" + action,
+				"iifff",
+				event->ctouchpad.touchpad,
+				event->ctouchpad.finger,
+				event->ctouchpad.x,
+				event->ctouchpad.y,
+				event->ctouchpad.pressure);
+			if(m_config.printEvents) {
+				LOG << m_oscAddress << " " << m_devName
+				    << " " << action << ": " << event->ctouchpad.touchpad << " " << event->ctouchpad.finger << " " << event->ctouchpad.x << " " << event->ctouchpad.y << " " << event->ctouchpad.pressure << std::endl;
+			}
+
+			return true;
+		}
+
 		case SDL_CONTROLLERSENSORUPDATE: {
 			std::string sensor = GetSensorName((SDL_SensorType)event->csensor.sensor);
 			lo::Address *sender = m_config.getOscSender();


### PR DESCRIPTION
Here's how this works (from the README):

On devices with a touchpad, such as the Playstation controllers, joyosc reports touchpad down, up, and motion events using the touchpaddown, touchpadup, and touchpad names, followed by five (two integer and three floating point) arguments: touchpad index (this will usually be 0, but may report higher indices if the device has more than one touchpad), finger index (starting at 0; higher values may be reported if the touchpad supports multi-touch), x and y (touchpad coordinates in the 0-1 range; upper left corner is 0, 0), and pressure (in the 0-1 range; 0 means no touch).