### PR TITLE
Rename motion data

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Options:
                        not being found, ex. MFi controllers on macOS
   -s, --sleep          Sleep time in usecs (default: 10000)
   -t, --triggers       Report trigger buttons as axis values
-  -r, --sensors        Report sensor values (gyro, accelerometer)
+  -v, --motion         Report motion data (gyro, accelerometer)
 
 Arguments:
   FILE                 Optional XML config file(s)
@@ -264,7 +264,7 @@ SDL Game Controller axis names: leftx, lefty, rightx, righty
 
 On devices with a touchpad, such as the Playstation controllers, joyosc reports touchpad down, up, and motion events using the touchpaddown, touchpadup, and touchpad names, followed by five (two integer and three floating point) arguments: touchpad index (this will usually be 0, but may report higher indices if the device has more than one touchpad), finger index (starting at 0; higher values may be reported if the touchpad supports multi-touch), x and y (touchpad coordinates in the 0-1 range; upper left corner is 0, 0), and pressure (in the 0-1 range; 0 means no touch).
 
-Also, joyosc can report x, y, z motion (acceleration and gyro aka rotation) data on devices which support this when invoked with the `--sensors` option. These use the following sensor names: accel, gyro (also leftaccel, leftgyro and rightaccel, rightgyro on some devices). _Note: These will generate lots of data when enabled._
+Also, joyosc can report x, y, z motion (acceleration and gyro aka rotation) data on devices which support this when invoked with the `--motion` option. These use the following sensor names: accel, gyro (also leftaccel, leftgyro and rightaccel, rightgyro on some devices). _Note: These will generate lots of data when enabled._
 
 _Note: Game Controller names seem to follow the general Playstation DualShock layout. Devices with more than 4 axes and ~20 buttons are probably best used as Joysticks._
 

--- a/src/joyosc/Config.cpp
+++ b/src/joyosc/Config.cpp
@@ -75,7 +75,7 @@ bool Config::parseCommandLine(int argc, char **argv) {
 		WINDOW,
 		SLEEP,
 		TRIGGER,
-		SENSORS
+		MOTION
 	};
 
 	// option and usage print descriptors
@@ -92,7 +92,7 @@ bool Config::parseCommandLine(int argc, char **argv) {
 		{WINDOW, 0, "w", "window", Options::Arg::None, "  -w, --window \tOpen window, helps on some platforms if device events are not being found, ex. MFi controllers on macOS"},
 		{SLEEP, 0, "s", "sleep", Options::Arg::Integer, "  -s, --sleep \tSleep time in usecs (default: 10000)"},
 		{TRIGGER, 0, "t", "triggers", Options::Arg::None, "  -t, --triggers \tReport trigger buttons as axis values"},
-		{SENSORS, 0, "r", "sensors", Options::Arg::None, "  -r, --sensors \tReport sensor values (gyro, accelerometer)"},
+		{MOTION, 0, "v", "motion", Options::Arg::None, "  -v, --motion \tReport motion data (gyro, accelerometer)"},
 		{UNKNOWN, 0, "", "", Options::Arg::Unknown, "\nArguments:"},
 		{UNKNOWN, 0, "", "", Options::Arg::None, "  FILE \tOptional XML config file(s)"},
 		{0, 0, 0, 0, 0, 0}
@@ -131,7 +131,7 @@ bool Config::parseCommandLine(int argc, char **argv) {
 	if(options.isSet(WINDOW))     {openWindow = true;}
 	if(options.isSet(SLEEP))      {sleepUS = options.getUInt(SLEEP);}
 	if(options.isSet(TRIGGER))    {triggersAsAxes = true;}
-	if(options.isSet(SENSORS))    {enableSensors = true;}
+	if(options.isSet(MOTION))     {enableMotion = true;}
 
 	return true;
 }
@@ -218,7 +218,7 @@ void Config::print() {
 	    << "joysticks only?: " << (joysticksOnly ? "true" : "false") << std::endl
 	    << "sleep us:        " << sleepUS << std::endl
 	    << "triggers as axes?: " << (triggersAsAxes ? "true" : "false") << std::endl
-	    << "enable sensors?: " << (enableSensors ? "true" : "false") << std::endl
+	    << "enable motion data?: " << (enableMotion ? "true" : "false") << std::endl
 	    << "device addresses: " << m_devices.size() << std::endl;
 	int index = 0;
 	for(auto &device : m_devices) {

--- a/src/joyosc/Config.h
+++ b/src/joyosc/Config.h
@@ -72,7 +72,7 @@ class Config {
 		bool openWindow = false; ///< open window? helps to receive events on some platforms
 		unsigned int sleepUS = 10000; ///< how long to sleep in the run loop
 		bool triggersAsAxes = false; ///< report trigger buttons as axis values
-		bool enableSensors = false; ///< report sensor values (gyro, accelerometer)
+		bool enableMotion = false; ///< report motion data (gyro, accelerometer)
 
 	/// \section Getters
 

--- a/src/joyosc/GameController.cpp
+++ b/src/joyosc/GameController.cpp
@@ -117,7 +117,7 @@ bool GameController::open(void *data) {
 	}
 
 	LOG << "GameController: opened " << getDeviceString() << std::endl;
-	if(m_controller && m_config.enableSensors) {
+	if(m_controller && m_config.enableMotion) {
 	  // enable available sensors
 	  SDL_SensorType sensors[] = {
 	    SDL_SENSOR_ACCEL,
@@ -208,14 +208,14 @@ bool GameController::handleEvent(void *data) {
 		case SDL_CONTROLLERSENSORUPDATE: {
 			std::string sensor = GetSensorName((SDL_SensorType)event->csensor.sensor);
 			lo::Address *sender = m_config.getOscSender();
-			sender->send(m_config.deviceAddress + m_oscAddress + "/sensor",
+			sender->send(m_config.deviceAddress + m_oscAddress + "/motion",
 				"sfff", sensor.c_str(),
 				event->csensor.data[0],
 				event->csensor.data[1],
 				event->csensor.data[2]);
 			if(m_config.printEvents) {
 				LOG << m_oscAddress << " " << m_devName
-				    << " sensor: " << sensor << " " << event->csensor.data[0] << " " << event->csensor.data[1] << " " << event->csensor.data[2] << std::endl;
+				    << " motion: " << sensor << " " << event->csensor.data[0] << " " << event->csensor.data[1] << " " << event->csensor.data[2] << std::endl;
 			}
 
 			return true;


### PR DESCRIPTION
This is a followup to #20 which, as suggested, renames `/sensor` to `/motion` and the `-r`/`--sensors` options to `-v`/`--motion`.