### PR TITLE
Rename sensor -> motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Options:
   -j, --joysticks-only Disable game controller support, joystick interface only
   -w, --window         Open window, helps on some platforms if device events are
                        not being found, ex. MFi controllers on macOS
-  -s, --sleep          Sleep time in usecs (default: 10000)
+  --sleep              Sleep time in usecs (default: 10000)
   -t, --triggers       Report trigger buttons as axis values
   -s, --sensors        Enable controller sensor events (accelerometer, gyro)
   -v, --verbose        Verbose printing

--- a/src/joyosc/GameController.cpp
+++ b/src/joyosc/GameController.cpp
@@ -230,7 +230,7 @@ bool GameController::handleEvent(SDL_Event *event) {
 
 		case SDL_CONTROLLERSENSORUPDATE: {
 			const std::string &sensor = nameForSensor((SDL_SensorType)event->csensor.sensor);
-			sender->send(Device::deviceAddress + m_address + "/sensor",
+			sender->send(Device::deviceAddress + m_address + "/motion",
 				"sfff", sensor.c_str(),
 				event->csensor.data[0],
 				event->csensor.data[1],
@@ -238,7 +238,7 @@ bool GameController::handleEvent(SDL_Event *event) {
 			);
 			if(Device::printEvents) {
 				LOG << m_address << " " << m_name
-				    << " sensor: " << sensor
+				    << " motion: " << sensor
 				    << " " << event->csensor.data[0]
 				    << " " << event->csensor.data[1]
 				    << " " << event->csensor.data[2] << std::endl;


### PR DESCRIPTION
As previously discussed, this renames `/sensor` to `/motion`. Also add a little correction to the README.